### PR TITLE
Fix 'no such file or directory' error on windows:

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -9,6 +9,7 @@ export function getCommand(command: "cwebp" | "dwebp") {
     switch (process.platform) {
         case "win32":
             platform = "windows-x64";
+            command = command + '.exe'
             break;
         case "linux":
             platform = "linux-x86-64";


### PR DESCRIPTION
[Error: ENOENT: no such file or directory, chmod 'node_modules\node-webp\webp\windows-x64\cwebp'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'chmod',
  path: 'node_modules\\node-webp\\webp\\windows-x64\\cwebp'
}